### PR TITLE
Added XUnit Coverage exclude parameters

### DIFF
--- a/Content/constants.cake
+++ b/Content/constants.cake
@@ -3,27 +3,27 @@ public static partial class Sitecore
     public static class Constants
     {
         // Generic parameters
-        public static string BUILD_CONFIGURATION { get; private set; }  
-        public static string SOLUTION_NAME       { get; private set; }        
+        public static string BUILD_CONFIGURATION { get; private set; }
+        public static string SOLUTION_NAME       { get; private set; }
         // Sitecore parameters
-        public static string SC_ADMIN_USER       { get; private set; }         
-        public static string SC_ADMIN_PASSWORD   { get; private set; }     
-        public static string SC_NODE_ENV         { get; private set; }           
-        public static string SC_NODE_ROLE        { get; private set; }          
-        public static string SC_SITE_URL         { get; private set; }           
+        public static string SC_ADMIN_USER       { get; private set; }
+        public static string SC_ADMIN_PASSWORD   { get; private set; }
+        public static string SC_NODE_ENV         { get; private set; }
+        public static string SC_NODE_ROLE        { get; private set; }
+        public static string SC_SITE_URL         { get; private set; }
         // Versioning
-        public static string VERSION             { get; private set; }             
-        public static string ASSEMBLY_VERSION    { get; private set; }     
+        public static string VERSION             { get; private set; }
+        public static string ASSEMBLY_VERSION    { get; private set; }
         // Source Control
-        public static string BRANCH              { get; private set; }          
-        public static string BRANCH_NAME         { get; private set; }          
+        public static string BRANCH              { get; private set; }
+        public static string BRANCH_NAME         { get; private set; }
         public static string COMMIT              { get; private set; }
         // Build Server
-        public static string BUILD_ID            { get; private set; }          
+        public static string BUILD_ID            { get; private set; }
         public static string BUILD_NAME          { get; private set; }
         public static string BUILD_NUMBER        { get; private set; }
 
-        public static string ROOT_DIR            { get; private set; }        
+        public static string ROOT_DIR            { get; private set; }
 
         public static string LIBS_DIR                          { get; private set; }
         public static string LIBS_PACKAGES_DIR                 { get; private set; }
@@ -47,6 +47,9 @@ public static partial class Sitecore
         public static string TESTS_COVERAGE_OUTPUT_DIR         { get; private set; }
         public static string XUNIT_TESTS_COVERAGE_OUTPUT_DIR   { get; private set; }
         public static string XUNIT_TESTS_COVERAGE_REGISTER     { get; private set; }
+        public static string XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS { get; private set; }
+        public static string XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS      { get; private set; }
+        public static string XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES       { get; private set; }
         public static string JEST_TESTS_COVERAGE_OUTPUT_DIR    { get; private set; }
         public static string PUBLISHING_TARGET_DIR             { get; private set; }
         public static string SC_LOCAL_WEBSITE_ROOT_DIR         { get; private set; }
@@ -58,16 +61,16 @@ public static partial class Sitecore
 
         public static void SetNames(
             string BuildConfiguration            = null,
-            string SolutionName                  = null,      
-            string ScAdminUser                   = null,       
-            string ScAdminPassword               = null,   
-            string ScNodeEnv                     = null,         
-            string ScNodeRole                    = null,        
-            string ScSiteUrl                     = null,         
-            string Version                       = null,           
-            string AssemblyVersion               = null,   
-            string Branch                        = null,        
-            string BranchName                    = null,        
+            string SolutionName                  = null,
+            string ScAdminUser                   = null,
+            string ScAdminPassword               = null,
+            string ScNodeEnv                     = null,
+            string ScNodeRole                    = null,
+            string ScSiteUrl                     = null,
+            string Version                       = null,
+            string AssemblyVersion               = null,
+            string Branch                        = null,
+            string BranchName                    = null,
             string Commit                        = null,
             string BuildId                       = null,
             string BuildName                     = null,
@@ -95,6 +98,9 @@ public static partial class Sitecore
             string TestsCoverageOutputDir        = null,
             string XunitTestsCoverageOutputDir   = null,
             string XunitTestsCoverageRegister    = null,
+            string XunitTestsCoverageExcludeAttributeFilters = null,
+            string XunitTestsCoverageExcludeFileFilters      = null,
+            string XunitTestsCoverageExcludeDirectories      = null,
             string JestTestsCoverageOutputDir    = null,
             string PublishingTargetDir           = null,
             string ScLocalWebsiteRootDir         = null,
@@ -144,7 +150,10 @@ public static partial class Sitecore
             TESTS_OUTPUT_DIR                  = TestsOutputDir                ?? "TESTS_OUTPUT_DIR"; 
             TESTS_COVERAGE_OUTPUT_DIR         = TestsCoverageOutputDir        ?? "TESTS_COVERAGE_OUTPUT_DIR"; 
             XUNIT_TESTS_COVERAGE_OUTPUT_DIR   = XunitTestsCoverageOutputDir   ?? "XUNIT_TESTS_COVERAGE_OUTPUT_DIR";
-            XUNIT_TESTS_COVERAGE_REGISTER     = XunitTestsCoverageRegister    ?? "XUNIT_TESTS_COVERAGE_REGISTER"; 
+            XUNIT_TESTS_COVERAGE_REGISTER     = XunitTestsCoverageRegister    ?? "XUNIT_TESTS_COVERAGE_REGISTER";
+            XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS = XunitTestsCoverageExcludeAttributeFilters ?? "XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS";
+            XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS      = XunitTestsCoverageExcludeFileFilters      ?? "XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS";
+            XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES       = XunitTestsCoverageExcludeDirectories      ?? "XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES";
             JEST_TESTS_COVERAGE_OUTPUT_DIR    = JestTestsCoverageOutputDir    ?? "JEST_TESTS_COVERAGE_OUTPUT_DIR"; 
             PUBLISHING_TARGET_DIR             = PublishingTargetDir           ?? "PUBLISHING_TARGET_DIR"; 
             SC_LOCAL_WEBSITE_ROOT_DIR         = ScLocalWebsiteRootDir         ?? "SC_LOCAL_WEBSITE_ROOT_DIR"; 

--- a/Content/parameters.cake
+++ b/Content/parameters.cake
@@ -56,6 +56,9 @@ public static partial class Sitecore
         public static string TestsCoverageOutputDir { get; private set; }
         public static string XUnitTestsCoverageOutputDir { get; private set; }
         public static string XUnitTestsCoverageRegister { get; private set; }
+        public static string XUnitTestsCoverageExcludeAttributeFilters { get; private set; }
+        public static string XUnitTestsCoverageExcludeFileFilters { get; private set; }
+        public static string XUnitTestsCoverageExcludeDirectories { get; private set; }
         public static string JestTestsCoverageOutputDir { get; private set; }
         public static string PublishingTargetDir { get; private set; }
         public static string ScLocalWebsiteRootDir { get; private set; }
@@ -114,6 +117,9 @@ public static partial class Sitecore
             string testsCoverageOutputDir =        null,
             string xUnitTestsCoverageOutputDir =   null,
             string xUnitTestsCoverageRegister =    null,
+            string xUnitTestsCoverageExcludeAttributeFilters = null,
+            string xUnitTestsCoverageExcludeFileFilters      = null,
+            string xUnitTestsCoverageExcludeDirectories      = null,
             string jestTestsCoverageOutputDir =    null,
             string publishingTargetDir =           null,
 
@@ -175,6 +181,9 @@ public static partial class Sitecore
             TestsCoverageOutputDir =        GetAbsoluteDirPath(GetParameterValue(Constants.TESTS_COVERAGE_OUTPUT_DIR,         testsCoverageOutputDir ??        $"{TestsOutputDir}/coverage"));
             XUnitTestsCoverageOutputDir =   GetAbsoluteDirPath(GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_OUTPUT_DIR,   xUnitTestsCoverageOutputDir ??   $"{TestsCoverageOutputDir}/xUnit"));
             XUnitTestsCoverageRegister =    GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_REGISTER,                        xUnitTestsCoverageRegister ??    $"user");
+            XUnitTestsCoverageExcludeAttributeFilters  = GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS,  xUnitTestsCoverageExcludeAttributeFilters  ?? "");
+            XUnitTestsCoverageExcludeFileFilters       = GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS,       xUnitTestsCoverageExcludeFileFilters       ?? "");
+            XUnitTestsCoverageExcludeDirectories       = GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES,        xUnitTestsCoverageExcludeDirectories       ?? "");
             JestTestsCoverageOutputDir =    GetAbsoluteDirPath(GetParameterValue(Constants.JEST_TESTS_COVERAGE_OUTPUT_DIR,    jestTestsCoverageOutputDir ??    $"{TestsCoverageOutputDir}/jest"));
             PublishingTargetDir =           GetPublishingTargetDir(                                                           publishingTargetDir);
 

--- a/Content/tasks.tests.unit.cake
+++ b/Content/tasks.tests.unit.cake
@@ -31,6 +31,19 @@ Sitecore.Tasks.RunServerUnitTestsTask = Task("Unit Tests :: Run Server Tests")
         _coverSettings.NoDefaultFilters = true;
         _coverSettings.ReturnTargetCodeOffset = 0;
 
+        void applyExclude<T>(ISet<T> filtersSet, string paramValue, Func<string, T> mapper)
+        {
+            if (!string.IsNullOrEmpty(paramValue))
+            {
+                var excludes = paramValue.Split(',').Select(mapper);
+                filtersSet.UnionWith(excludes);
+            }
+        }
+
+        applyExclude(_coverSettings.ExcludedAttributeFilters, Sitecore.Parameters.XUnitTestsCoverageExcludeAttributeFilters, x => x);
+        applyExclude(_coverSettings.ExcludedFileFilters,      Sitecore.Parameters.XUnitTestsCoverageExcludeFileFilters, x => x);
+        applyExclude(_coverSettings.ExcludeDirectories,       Sitecore.Parameters.XUnitTestsCoverageExcludeDirectories, x => Directory($"{Sitecore.Parameters.SrcDir}/{x}"));
+
         var _directories = GetDirectories(
                 $"{Sitecore.Parameters.SrcDir}/**/bin", 
                 fileSystemInfo => fileSystemInfo.Path.FullPath.IndexOf("node_modules", StringComparison.OrdinalIgnoreCase) < 0


### PR DESCRIPTION
Added XUnit Coverage exclude parameters - instead of #22 Generated.cs excluded from code coverage 