### PR TITLE
Add parameter to disable shadow copy in xUnit

### DIFF
--- a/Content/constants.cake
+++ b/Content/constants.cake
@@ -56,6 +56,7 @@ public static partial class Sitecore
         public static string XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS { get; private set; }
         public static string XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS      { get; private set; }
         public static string XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES       { get; private set; }
+        public static string XUNIT_SHADOW_COPY         { get; private set; }
         public static string JEST_TESTS_COVERAGE_OUTPUT_DIR    { get; private set; }
         public static string PUBLISH_SERIALIZATION_ITEMS       { get; private set; }
         public static string PUBLISHING_TARGET_DIR             { get; private set; }
@@ -116,6 +117,7 @@ public static partial class Sitecore
             string XunitTestsCoverageExcludeAttributeFilters = null,
             string XunitTestsCoverageExcludeFileFilters      = null,
             string XunitTestsCoverageExcludeDirectories      = null,
+            string XunitShadowCopy               = null,
             string JestTestsCoverageOutputDir    = null,
             string PublishSerializationItems     = null,
             string PublishingTargetDir           = null,
@@ -179,6 +181,7 @@ public static partial class Sitecore
             XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS = XunitTestsCoverageExcludeAttributeFilters ?? "XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS";
             XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS      = XunitTestsCoverageExcludeFileFilters      ?? "XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS";
             XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES       = XunitTestsCoverageExcludeDirectories      ?? "XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES";
+            XUNIT_SHADOW_COPY                 = XunitShadowCopy               ?? "XUNIT_SHADOW_COPY";
             JEST_TESTS_COVERAGE_OUTPUT_DIR    = JestTestsCoverageOutputDir    ?? "JEST_TESTS_COVERAGE_OUTPUT_DIR";
             PUBLISH_SERIALIZATION_ITEMS       = PublishSerializationItems     ?? "PUBLISH_SERIALIZATION_ITEMS";
             PUBLISHING_TARGET_DIR             = PublishingTargetDir           ?? "PUBLISHING_TARGET_DIR";

--- a/Content/parameters.cake
+++ b/Content/parameters.cake
@@ -65,6 +65,7 @@ public static partial class Sitecore
         public static string XUnitTestsCoverageExcludeAttributeFilters { get; private set; }
         public static string XUnitTestsCoverageExcludeFileFilters { get; private set; }
         public static string XUnitTestsCoverageExcludeDirectories { get; private set; }
+        public static bool   XUnitShadowCopy { get; private set; }
         public static string JestTestsCoverageOutputDir { get; private set; }
         public static bool   PublishSerializationItems { get; private set; }
         public static string PublishingTargetDir { get; private set; }
@@ -135,6 +136,7 @@ public static partial class Sitecore
             string xUnitTestsCoverageExcludeAttributeFilters = null,
             string xUnitTestsCoverageExcludeFileFilters      = null,
             string xUnitTestsCoverageExcludeDirectories      = null,
+            string xUnitShadowCopy =               null,
             string jestTestsCoverageOutputDir =    null,
             string publishSerializationItems =     null,
             string publishingTargetDir =           null,
@@ -210,6 +212,7 @@ public static partial class Sitecore
             XUnitTestsCoverageExcludeAttributeFilters  = GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_EXCLUDE_ATTRIBUTE_FILTERS,  xUnitTestsCoverageExcludeAttributeFilters  ?? "");
             XUnitTestsCoverageExcludeFileFilters       = GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_EXCLUDE_FILE_FILTERS,       xUnitTestsCoverageExcludeFileFilters       ?? "");
             XUnitTestsCoverageExcludeDirectories       = GetParameterValue(Constants.XUNIT_TESTS_COVERAGE_EXCLUDE_DIRECTORIES,        xUnitTestsCoverageExcludeDirectories       ?? "");
+            XUnitShadowCopy =               ToBoolean(GetParameterValue(Constants.XUNIT_SHADOW_COPY,                          xUnitShadowCopy ??               "true"));
             JestTestsCoverageOutputDir =    GetAbsoluteDirPath(GetParameterValue(Constants.JEST_TESTS_COVERAGE_OUTPUT_DIR,    jestTestsCoverageOutputDir ??    $"{TestsCoverageOutputDir}/jest"));
 
             // Pathes

--- a/Content/tasks.tests.unit.cake
+++ b/Content/tasks.tests.unit.cake
@@ -62,7 +62,8 @@ Sitecore.Tasks.RunServerUnitTestsTask = Task("Unit Tests :: Run Server Tests")
                 Parallelism = ParallelismOption.None,
                 NoAppDomain = false,
                 OutputDirectory = Sitecore.Parameters.TestsOutputDir,
-                ReportName = "xUnitTestResults"
+                ReportName = "xUnitTestResults",
+                ShadowCopy = Sitecore.Parameters.XUnitShadowCopy
             };
 
         OpenCover(


### PR DESCRIPTION
Some assemblies have `SkipedDueTo="MissingPdb"` argument in OpenCover report, so coverage information is not full. According OpenCover [documentation](https://github.com/opencover/opencover/blob/master/main/OpenCover.Documentation/Usage.pdf) (FAQ/Why do I have no results?) this can be corrected by disabling shadow copying in test tools