### PR TITLE
Publishing tasks optimizations

### DIFF
--- a/Content/tasks.publish.cake
+++ b/Content/tasks.publish.cake
@@ -101,6 +101,7 @@ Action<string, string, string, MSBuildToolVersion> publishProject = (projectFile
         .SetVerbosity(Verbosity.Minimal)
         .UseToolVersion(msBuildToolVersion)
         .WithTarget("Build")
+        .WithProperty("BuildProjectReferences", "false")
         .WithProperty("DeployOnBuild", "true")
         .WithProperty("DeployDefaultTarget", "WebPublish")
         .WithProperty("WebPublishMethod", "FileSystem")


### PR DESCRIPTION
Disabling "BuildProjectReferences" can significantly reduce publishing time for large solutions. The only downside of this is that solution build would be required first ("Build :: Build Server Code").